### PR TITLE
[FIX] - Game scale

### DIFF
--- a/sources/client/src/components/RoomGame.vue
+++ b/sources/client/src/components/RoomGame.vue
@@ -11,6 +11,12 @@
 
   &__renderer
     height: 100%
+  canvas
+    position: fixed
+    top: 0
+    bottom: 0
+    right: 0
+    left: 0
 </style>
 
 <script lang="ts">
@@ -48,7 +54,10 @@ export default class RoomGame extends Vue {
       return {
         parent: this.$el,
         scale: {
-          mode: Phaser.Scale.RESIZE
+          mode: Phaser.Scale.FIT,
+          autoCenter: Phaser.Scale.CENTER_BOTH,
+          width: 736,
+          height: 414
         },
         input: {
           gamepad: false,

--- a/sources/client/src/components/VirtualJoystick.vue
+++ b/sources/client/src/components/VirtualJoystick.vue
@@ -12,6 +12,7 @@
   bottom: 0
   width: 100%
   height: 100%
+  z-index: 10
   .nipple
     pointer-events: all
 </style>


### PR DESCRIPTION
## ❓ What? Why
<!-- Intérêt de cette PR ? Qu'est ce qu'elle ajoute en gros -->
Permet d'avoir une longueur et une largeur de base pour le jeu, afin de pouvoir ensuite l'adapter sur différentes tailles d'écran. On travaille donc sur une base d'un **iPhone 6/7/8**, avec une longueur du jeu fixée à 736px, et une hauteur fixée à 414px. 
On utilise donc ensuite le **ScaleManager** de Phaser afin de redimensionner le jeu. Il faut toujours avoir en tête cette taille, car lorsque l'on exporte des assets ou n'importe quoi de visuel, je me suis vite rendu compte que les tailles étaient énormes. 
          
## 📋 Spécifications fonctionnelles
<!-- Si possible, une liste plus ou moins précise de ce qui a été fait techniquement parlant, si c'est trop chiant, on met rien :trollface: -->
- [x] Utilisation du `Phaser.Scale.FIT` mode afin que le jeu soit proportionnel à la taille d'écran, tout en conservant sa longueur et hauteur de base
- [x] Utilisation de `Phaser.Scale.CENTER_BOTH` afin de centrer le jeu horizontalement et verticalement sur le viewport
