### PR TITLE
[FIX] - SVGMapper export

### DIFF
--- a/sources/shared/src/@types/level.d.ts
+++ b/sources/shared/src/@types/level.d.ts
@@ -7,12 +7,28 @@ export type LevelBackground = {
   to: Color
 }
 
+export type Sprites = { [layer: string]: Sprite[] }
+
+export interface Sprite {
+  id?: string
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  texture: string,
+  frame?: string
+}
+
 export interface Body {
   x: number,
   y: number,
   width: number,
   height: number,
-  texture?: string
+  texture?: string,
+  pivot: {
+    x: number,
+    y: number
+  }
 }
 
 export interface Level {

--- a/sources/shared/src/@types/level.d.ts
+++ b/sources/shared/src/@types/level.d.ts
@@ -7,18 +7,6 @@ export type LevelBackground = {
   to: Color
 }
 
-export type Sprites = { [layer: string]: Sprite[] }
-
-export interface Sprite {
-  id?: string
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  texture: string,
-  frame?: string
-}
-
 export interface Body {
   x: number,
   y: number,

--- a/sources/shared/src/@types/sprite.d.ts
+++ b/sources/shared/src/@types/sprite.d.ts
@@ -7,5 +7,9 @@ export interface Sprite {
   width: number,
   height: number,
   texture: string,
-  frame?: string
+  frame?: string,
+  pivot: {
+    x: number,
+    y: number
+  }
 }


### PR DESCRIPTION
## ❓ What? Why
<!-- Intérêt de cette PR ? Qu'est ce qu'elle ajoute en gros -->
Correction de diverses petites choses sur **SVGMapper** et ajout de petites fonctionnalitées

## 📋 Spécifications fonctionnelles
<!-- Si possible, une liste plus ou moins précise de ce qui a été fait techniquement parlant, si c'est trop chiant, on met rien :trollface: -->
- [x] Suppression des suffixes `-Copy-xxx` lorsque sketch exporte des élements qui ont été dupliqués afin de toujours faire référence au bon nom de la texture dans l'atlas
    - Cela nous permet donc sur sketch de dupliquer des élements en étant sûr que l'on référencera toujours la même texture
- [x] Ajout d'un paramètre `pivot` pour chacun des objets présent dans la map (par défault `{x: 0, y: 0}` pour mimer le point d'ancrage par défaut de Sketch
- [x] Résolution d'un problème lorsqu'il n y avait aucun bodies de définis dans la map
- [x] Résolution d'un problème avec certains noeuds SVG non définis
- [x] Ajout de commentaire lorsque nécessaire

