### PR TITLE
[FEAT] Make canvas size right

### DIFF
--- a/sources/client/src/components/RoomGame.vue
+++ b/sources/client/src/components/RoomGame.vue
@@ -54,10 +54,10 @@ export default class RoomGame extends Vue {
       return {
         parent: this.$el,
         scale: {
-          mode: Phaser.Scale.ENVELOP,
+          mode: Phaser.Scale.FIT,
           autoCenter: Phaser.Scale.CENTER_BOTH,
-          width: 667,
-          height: 375
+          width: Math.max(window.innerWidth, window.innerHeight),
+          height: Math.min(window.innerWidth, window.innerHeight)
         },
         input: {
           gamepad: false,

--- a/sources/client/src/components/RoomGame.vue
+++ b/sources/client/src/components/RoomGame.vue
@@ -54,7 +54,7 @@ export default class RoomGame extends Vue {
       return {
         parent: this.$el,
         scale: {
-          mode: Phaser.Scale.FIT,
+          mode: Phaser.Scale.ENVELOP,
           autoCenter: Phaser.Scale.CENTER_BOTH,
           width: 667,
           height: 375


### PR DESCRIPTION
## ❓ What? Why
Le canvas du jeu ne prend pas tout l'espace de l'écran.

## 📋 Spécifications fonctionnelles
Ajuster la configuration du `ScaleManager`

