### PR TITLE
[CI] - Correct server url for previews instances

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,6 @@
 
 [build.environment]
   VUE_APP_SOCKET_ENDPOINT = ""
+
+[context.deploy-preview]
+  command = "unset VUE_APP_SOCKET_ENDPOINT && yarn build:client"

--- a/sources/client/package.json
+++ b/sources/client/package.json
@@ -5,7 +5,7 @@
   "licence": "MIT",
   "scripts": {
     "dev": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "node ./scripts/create-env.js && vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/sources/client/scripts/create-env.js
+++ b/sources/client/scripts/create-env.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+
+if (process.env.CONTEXT && process.env.CONTEXT === 'deploy-preview') {
+  const reviewId = process.env.REVIEW_ID
+  console.log(`Deploy preview #${reviewId} build detected. Setting an environment variable for the associated heroku instance of this preview.`)
+  const deployServerPreviewUrl = `https://street-of-age-pr-${reviewId}.herokuapp.com/`
+  fs.writeFileSync('./.env', `VUE_APP_SOCKET_ENDPOINT=${deployServerPreviewUrl}`)
+  console.log(`Successfully written env file! ${deployServerPreviewUrl} will be used for backend.`)
+}


### PR DESCRIPTION
## ❓ What? Why
<!-- Intérêt de cette PR ? Qu'est ce qu'elle ajoute en gros -->
Cela nous permettra enfin d'avoir des instances de preview sur Netlify qui utilisent l'url correspond à la même PR sur heroku. Actuellement, les instances de preview utilisaient la version de production du backend. Désormais, on utilise correctement la version correspond à la PR concernée
## 📋 Spécifications fonctionnelles
<!-- Si possible, une liste plus ou moins précise de ce qui a été fait techniquement parlant, si c'est trop chiant, on met rien :trollface: -->
- [x] Ajout d'un script `create-env.js` permettant d'adapter la variable d'environnement `VUE_APP_SOCKET_ENDPOINT` afin de la faire correspondre avec la bonne version de preview sur Heroku
- [x] Modification du fichier `netlify.toml` afin de supprimer la variables d'environnement avant le build pour qu'il utilise celle présent dans le fichier .env créé par le nouveau script  

